### PR TITLE
Add functionality for non-scalar structs

### DIFF
--- a/lib/private/rosmsgSerializeStruct.m
+++ b/lib/private/rosmsgSerializeStruct.m
@@ -9,32 +9,35 @@ p = fieldnames(msg);
 
 for ii = 1:numel(p)
     name = char(p{ii});
-    obj = msg.(name);
-    if isstruct(obj)
-        [packed, jj] = rosmsgSerializeStruct(obj, packed, jj);
-    else
-        new_vec = typecast(obj, 'uint8');
-        numel_new_vec = numel(new_vec);
-        new_vec_len = typecast(numel_new_vec, 'uint8');
-        
-        if iscolumn(new_vec_len)
-            %packed = horzcat(packed, new_vec_len');
-            packed(jj:jj+8-1) = new_vec_len';
+    msg_len = length(msg);
+    for kk = 1:msg_len
+        obj = msg(kk).(name);
+        if isstruct(obj)
+            [packed, jj] = rosmsgSerializeStruct(obj, packed, jj);
         else
-            %packed = horzcat(packed, new_vec_len);
-            packed(jj:jj+8-1) = new_vec_len;
+            new_vec = typecast(obj, 'uint8');
+            numel_new_vec = numel(new_vec);
+            new_vec_len = typecast(numel_new_vec, 'uint8');
+
+            if iscolumn(new_vec_len)
+                %packed = horzcat(packed, new_vec_len');
+                packed(jj:jj+8-1) = new_vec_len';
+            else
+                %packed = horzcat(packed, new_vec_len);
+                packed(jj:jj+8-1) = new_vec_len;
+            end
+
+            jj = jj + 8;
+
+            if iscolumn(new_vec)
+                %packed = horzcat(packed, new_vec');
+                packed(jj:jj+numel_new_vec-1) = new_vec';
+            else
+                packed(jj:jj+numel_new_vec-1) = new_vec;
+            end
+
+            jj = jj + numel_new_vec;
         end
-        
-        jj = jj + 8;
-        
-        if iscolumn(new_vec)
-            %packed = horzcat(packed, new_vec');
-            packed(jj:jj+numel_new_vec-1) = new_vec';
-        else
-            packed(jj:jj+numel_new_vec-1) = new_vec;
-        end
-        
-        jj = jj + numel_new_vec;
     end
 end
 


### PR DESCRIPTION
Code generation fails if there is an non-scalar struct for a given message, e.g. string[] example_strings. Each example_strings has two fields, so the original code cannot access that field for code generation.