### PR TITLE
Add functionality for incoming non scalar data types

### DIFF
--- a/lib/private/rosmsgUnpack.m
+++ b/lib/private/rosmsgUnpack.m
@@ -13,17 +13,20 @@ function [msg_out, depth_out] = inject_data(msg, inarr, jj)
 p = fieldnames(msg);
 for ii = 1:numel(p)
     name = char(p{ii});
-    obj = msg.(name);
-    
-    if isstruct(obj)
-        [msg.(name), jj] = inject_data(obj, inarr, jj);
-    else
-        leaf_len = typecast(inarr(jj:jj+8-1), 'double');
-        jj = jj + 8;
-        c = class(msg.(name));
-        temp = typecast(inarr(jj:jj+leaf_len(1)-1), c);
-        msg.(name) = temp(1:numel(msg.(name)));
-        jj = jj + leaf_len(1);
+    msg_len = length(msg)
+    for kk = 1:msg_len
+        obj = msg(kk).(name);
+
+        if isstruct(obj)
+            [msg.(name), jj] = inject_data(obj, inarr, jj);
+        else
+            leaf_len = typecast(inarr(jj:jj+8-1), 'double');
+            jj = jj + 8;
+            c = class(msg.(name));
+            temp = typecast(inarr(jj:jj+leaf_len(1)-1), c);
+            msg.(name) = temp(1:numel(msg.(name)));
+            jj = jj + leaf_len(1);
+        end
     end
 end
 msg_out = msg;

--- a/lib/private/rosmsgUnpack.m
+++ b/lib/private/rosmsgUnpack.m
@@ -18,13 +18,13 @@ for ii = 1:numel(p)
         obj = msg(kk).(name);
 
         if isstruct(obj)
-            [msg.(name), jj] = inject_data(obj, inarr, jj);
+            [msg(kk).(name), jj] = inject_data(obj, inarr, jj);
         else
             leaf_len = typecast(inarr(jj:jj+8-1), 'double');
             jj = jj + 8;
-            c = class(msg.(name));
+            c = class(msg(kk).(name));
             temp = typecast(inarr(jj:jj+leaf_len(1)-1), c);
-            msg.(name) = temp(1:numel(msg.(name)));
+            msg(kk).(name) = temp(1:numel(msg(kk).(name)));
             jj = jj + leaf_len(1);
         end
     end


### PR DESCRIPTION
Code generation fails if there is an non-scalar struct for a given message, e.g. string[] example_strings. Each example_strings has two fields, so the original code cannot access that field for code generation.